### PR TITLE
45 use ksqldb log level in deploy openfactory application

### DIFF
--- a/openfactory/openfactory_manager.py
+++ b/openfactory/openfactory_manager.py
@@ -278,6 +278,10 @@ class OpenFactoryManager(OpenFactory):
                 var, val = item.split('=')
                 env.append(f"{var.strip()}={val.strip()}")
 
+        # if KSQLDB_LOG_LEVEL is not set by user, set it to the default value
+        if not any(var.startswith("KSQLDB_LOG_LEVEL=") for var in env):
+            env.append(f"KSQLDB_LOG_LEVEL={config.KSQLDB_LOG_LEVEL}")
+
         try:
             dal.docker_client.services.create(
                 image=application['image'],

--- a/tests/integration-tests/apps/mocked_app.py
+++ b/tests/integration-tests/apps/mocked_app.py
@@ -27,7 +27,9 @@ class TestApp(OpenFactoryApp):
 
 app = TestApp(
     app_uuid='TEST-APP',
-    ksqlClient=KSQLDBClient(os.environ.get("KSQLDB_URL", "http://localhost:8088")),
+    ksqlClient=KSQLDBClient(
+            ksqldb_url=os.environ.get("KSQLDB_URL", "http://localhost:8088"),
+            loglevel=os.environ.get("KSQLDB_LOG_LEVEL", "WARNING")),
     bootstrap_servers=os.environ.get("KAFKA_BROKER", "localhost:9092")
 )
 app.run()

--- a/tests/integration-tests/configs/app.yml
+++ b/tests/integration-tests/configs/app.yml
@@ -3,3 +3,5 @@ apps:
   test-app:
     uuid: TEST-APP
     image: ofa/test-app
+    environment:
+      - KSQLDB_LOG_LEVEL=DEBUG

--- a/tests/openfactory/test_openfactorymanager.py
+++ b/tests/openfactory/test_openfactorymanager.py
@@ -322,6 +322,7 @@ class TestOpenFactoryManager(unittest.TestCase):
 
         # Mock config values
         mock_config.OPENFACTORY_NETWORK = "mock_network"
+        mock_config.KSQLDB_LOG_LEVEL = "MOCK_LOG_LEVEL"
 
         ksqlMock = MagicMock()
         ksqlMock.ksqldb_url = "mock_ksqldb_url"
@@ -330,7 +331,7 @@ class TestOpenFactoryManager(unittest.TestCase):
         application = {
             'uuid': 'test-app',
             'image': 'test-image',
-            'environment': ['VAR1=value1', 'VAR2=value2']
+            'environment': ['VAR1=value1', 'VAR2=value2', 'KSQLDB_LOG_LEVEL=MOCK_USER_LOG_LEVEL']
         }
 
         # Call the method to test
@@ -347,7 +348,8 @@ class TestOpenFactoryManager(unittest.TestCase):
                 'KSQLDB_URL=mock_ksqldb_url',
                 'DOCKER_SERVICE=test-app',
                 'VAR1=value1',
-                'VAR2=value2'
+                'VAR2=value2',
+                'KSQLDB_LOG_LEVEL=MOCK_USER_LOG_LEVEL'
             ],
             networks=['mock_network']
         )
@@ -367,6 +369,7 @@ class TestOpenFactoryManager(unittest.TestCase):
 
         # Mock config values
         mock_config.OPENFACTORY_NETWORK = "mock_network"
+        mock_config.KSQLDB_LOG_LEVEL = "MOCK_LOG_LEVEL"
 
         ksqlMock = MagicMock()
         ksqlMock.ksqldb_url = "mock_ksqldb_url"
@@ -392,7 +395,8 @@ class TestOpenFactoryManager(unittest.TestCase):
                 'APP_UUID=test-app',
                 'KAFKA_BROKER=mokded_bootstrap_servers',
                 'KSQLDB_URL=mock_ksqldb_url',
-                'DOCKER_SERVICE=test-app'
+                'DOCKER_SERVICE=test-app',
+                'KSQLDB_LOG_LEVEL=MOCK_LOG_LEVEL'
             ],
             networks=['mock_network']
         )


### PR DESCRIPTION
- Pass `KSQLDB_LOG_LEVEL` to app container
- Adjust tests to validate `KSQLDB_LOG_LEVEL` is passed to container