### PR TITLE
59 deploy from folder

### DIFF
--- a/openfactory/ofa/__init__.py
+++ b/openfactory/ofa/__init__.py
@@ -10,12 +10,3 @@ import openfactory.ofa.device as device
 import openfactory.ofa.app as app
 import openfactory.ofa.asset as asset
 
-# models
-"""
-from openfactory.models.configurations import Configuration
-from openfactory.models.agents import Agent
-from openfactory.models.compose import ComposeProject
-from openfactory.models.containers import DockerContainer
-from openfactory.models.nodes import Node
-from openfactory.models.infrastack import InfraStack
-"""

--- a/openfactory/ofa/app/down.py
+++ b/openfactory/ofa/app/down.py
@@ -1,13 +1,16 @@
 import click
 from openfactory import OpenFactoryManager
 from openfactory.ofa.ksqldb import ksql
+from openfactory.ofa.utils import process_yaml_files
 
 
 @click.command(name='down')
-@click.argument('yaml_config_file',
-                type=click.Path(exists=True),
-                nargs=1)
-def click_down(yaml_config_file):
-    """ Tear down OpenFactory applications """
+@click.argument('path', type=click.Path(exists=True), nargs=1)
+@click.option('--dry-run', is_flag=True, help="Only show which YAML files would be shut down.")
+def click_down(path, dry_run):
+    """ Tear down OpenFactory applications from a YAML config file or from a folder """
     ofa = OpenFactoryManager(ksqlClient=ksql.client)
-    ofa.shut_down_apps_from_config_file(yaml_config_file)
+    process_yaml_files(path, dry_run,
+                       action_func=ofa.shut_down_apps_from_config_file,
+                       action_name="shut down",
+                       pattern='app_*.yml')

--- a/openfactory/ofa/app/up.py
+++ b/openfactory/ofa/app/up.py
@@ -1,13 +1,16 @@
 import click
 from openfactory import OpenFactoryManager
 from openfactory.ofa.ksqldb import ksql
+from openfactory.ofa.utils import process_yaml_files
 
 
 @click.command(name='up')
-@click.argument('yaml_config_file',
-                type=click.Path(exists=True),
-                nargs=1)
-def click_up(yaml_config_file):
-    """ Deploy OpenFactory applications """
+@click.argument('path', type=click.Path(exists=True), nargs=1)
+@click.option('--dry-run', is_flag=True, help="Only show which YAML files would be deployed.")
+def click_up(path, dry_run):
+    """ Deploy OpenFactory applications from a YAML config file or from a folder """
     ofa = OpenFactoryManager(ksqlClient=ksql.client)
-    ofa.deploy_apps_from_config_file(yaml_config_file)
+    process_yaml_files(path, dry_run,
+                       action_func=ofa.deploy_apps_from_config_file,
+                       action_name="deployed",
+                       pattern='app_*.yml')

--- a/openfactory/ofa/device/down.py
+++ b/openfactory/ofa/device/down.py
@@ -1,13 +1,16 @@
 import click
 from openfactory import OpenFactoryManager
 from openfactory.ofa.ksqldb import ksql
+from openfactory.ofa.utils import process_yaml_files
 
 
 @click.command(name='down')
-@click.argument('yaml_config_file',
-                type=click.Path(exists=True),
-                nargs=1)
-def click_down(yaml_config_file):
-    """ Tear down devices """
+@click.argument('path', type=click.Path(exists=True), nargs=1)
+@click.option('--dry-run', is_flag=True, help="Only show which YAML files would be shut down.")
+def click_down(path, dry_run):
+    """ Tear down devices from a YAML config file or from a folder """
     ofa = OpenFactoryManager(ksqlClient=ksql.client)
-    ofa.shut_down_devices_from_config_file(yaml_config_file)
+    process_yaml_files(path, dry_run,
+                       action_func=ofa.shut_down_devices_from_config_file,
+                       action_name="shut down",
+                       pattern='dev_*.yml')

--- a/openfactory/ofa/device/up.py
+++ b/openfactory/ofa/device/up.py
@@ -1,13 +1,16 @@
 import click
 from openfactory import OpenFactoryManager
 from openfactory.ofa.ksqldb import ksql
+from openfactory.ofa.utils import process_yaml_files
 
 
 @click.command(name='up')
-@click.argument('yaml_config_file',
-                type=click.Path(exists=True),
-                nargs=1)
-def click_up(yaml_config_file):
-    """ Deploy devices """
+@click.argument('path', type=click.Path(exists=True), nargs=1)
+@click.option('--dry-run', is_flag=True, help="Only show which YAML files would be deployed.")
+def click_up(path, dry_run):
+    """ Deploy devices from a YAML config file or from a folder """
     ofa = OpenFactoryManager(ksqlClient=ksql.client)
-    ofa.deploy_devices_from_config_file(yaml_config_file)
+    process_yaml_files(path, dry_run,
+                       action_func=ofa.deploy_devices_from_config_file,
+                       action_name="deployed",
+                       pattern='dev_*.yml')

--- a/openfactory/ofa/utils.py
+++ b/openfactory/ofa/utils.py
@@ -1,0 +1,26 @@
+import os
+from openfactory.utils import find_yaml_files
+from openfactory.models.user_notifications import user_notify
+
+
+def process_yaml_files(path, dry_run, action_func, action_name="process", pattern='app_*.yml'):
+    """ Generic processor for YAML files (single or folder) with dry-run support """
+    if os.path.isfile(path):
+        if dry_run:
+            user_notify.info(f"[DRY-RUN] {path} would be {action_name}.")
+        else:
+            action_func(path)
+
+    elif os.path.isdir(path):
+        yaml_files = find_yaml_files(path, pattern=pattern)
+
+        if not yaml_files:
+            user_notify.fail(f"No YAML files found in '{path}'.")
+            return
+
+        for yaml_file in yaml_files:
+            if dry_run:
+                user_notify.info(f"[DRY-RUN] {yaml_file} would be {action_name}.")
+            else:
+                user_notify.info(f"[INFO] {action_name.capitalize()} from '{yaml_file}' ...")
+                action_func(yaml_file)

--- a/openfactory/utils/__init__.py
+++ b/openfactory/utils/__init__.py
@@ -2,6 +2,8 @@
 OpenFactory utils module
 """
 
+import glob
+import os
 from openfactory.config import load_yaml
 from openfactory.utils.docker_compose_up import docker_compose_up
 from openfactory.utils.open_uris import open_ofa
@@ -15,3 +17,12 @@ def get_nested(data, keys, default=None):
         else:
             return default
     return data
+
+def find_yaml_files(folder_path, pattern='app_*.yml'):
+    """ Recursively find YAML files matching a pattern in a folder and its subfolders """
+    if not os.path.isdir(folder_path):
+        raise ValueError(f"{folder_path} is not a valid directory.")
+
+    search_pattern = os.path.join(folder_path, '**', pattern)
+    yaml_files = sorted(glob.glob(search_pattern, recursive=True))
+    return yaml_files

--- a/tests/openfactory/ofa/app/test_click_up.py
+++ b/tests/openfactory/ofa/app/test_click_up.py
@@ -11,7 +11,8 @@ class TestAppUp(TestCase):
     """
 
     @patch("openfactory.ofa.app.up.OpenFactoryManager")
-    def test_app_up(self, mock_openfactory_manager):
+    @patch("openfactory.ofa.app.up.process_yaml_files")
+    def test_app_up(self, mock_process_yaml_files, mock_openfactory_manager):
         """
         Test deploy_apps_from_config_file called correctly
         """
@@ -21,8 +22,11 @@ class TestAppUp(TestCase):
         runner = CliRunner()
         config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                    'mock/mock_apps.yml')
-        result = runner.invoke(ofa.app.click_up, [config_file])
-        mock_instance.deploy_apps_from_config_file.assert_called_once_with(config_file)
+        result = runner.invoke(ofa.app.click_up, [config_file, '--dry-run'])
+        mock_process_yaml_files.assert_called_once_with(config_file, True,
+                                                        action_func=mock_instance.deploy_apps_from_config_file,
+                                                        action_name="deployed",
+                                                        pattern='app_*.yml')
         self.assertEqual(result.exit_code, 0)
 
     def test_app_up_none_existent_file(self):
@@ -31,9 +35,9 @@ class TestAppUp(TestCase):
         """
         runner = CliRunner()
         result = runner.invoke(ofa.app.click_up, ['/does/not/exist/config_file.yml'])
-        expect = ("Usage: up [OPTIONS] YAML_CONFIG_FILE\n"
+        expect = ("Usage: up [OPTIONS] PATH\n"
                   "Try 'up --help' for help.\n"
                   "\n"
-                  "Error: Invalid value for 'YAML_CONFIG_FILE': Path '/does/not/exist/config_file.yml' does not exist.\n")
+                  "Error: Invalid value for 'PATH': Path '/does/not/exist/config_file.yml' does not exist.\n")
         self.assertEqual(result.output, expect)
         self.assertEqual(result.exit_code, 2)

--- a/tests/openfactory/ofa/device/test_click_down.py
+++ b/tests/openfactory/ofa/device/test_click_down.py
@@ -11,7 +11,8 @@ class TestDeviceDown(TestCase):
     """
 
     @patch("openfactory.ofa.device.down.OpenFactoryManager")
-    def test_device_down(self, mock_openfactory_manager):
+    @patch("openfactory.ofa.device.down.process_yaml_files")
+    def test_device_down(self, mock_process_yaml_files, mock_openfactory_manager):
         """
         Test shut_down_devices_from_config_file called correctly
         """
@@ -21,8 +22,11 @@ class TestDeviceDown(TestCase):
         runner = CliRunner()
         config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                    'mock/mock_devices.yml')
-        result = runner.invoke(ofa.device.click_down, [config_file])
-        mock_instance.shut_down_devices_from_config_file.assert_called_once_with(config_file)
+        result = runner.invoke(ofa.device.click_down, [config_file, '--dry-run'])
+        mock_process_yaml_files.assert_called_once_with(config_file, True,
+                                                        action_func=mock_instance.shut_down_devices_from_config_file,
+                                                        action_name="shut down",
+                                                        pattern='dev_*.yml')
         self.assertEqual(result.exit_code, 0)
 
     def test_device_down_none_existent_file(self):
@@ -31,8 +35,8 @@ class TestDeviceDown(TestCase):
         """
         runner = CliRunner()
         result = runner.invoke(ofa.device.click_down, ['/does/not/exist/config_file.yml'])
-        expect = ("Usage: down [OPTIONS] YAML_CONFIG_FILE\n"
+        expect = ("Usage: down [OPTIONS] PATH\n"
                   "Try 'down --help' for help.\n"
                   "\n"
-                  "Error: Invalid value for 'YAML_CONFIG_FILE': Path '/does/not/exist/config_file.yml' does not exist.\n")
+                  "Error: Invalid value for 'PATH': Path '/does/not/exist/config_file.yml' does not exist.\n")
         self.assertEqual(result.output, expect)

--- a/tests/openfactory/ofa/device/test_click_up.py
+++ b/tests/openfactory/ofa/device/test_click_up.py
@@ -11,7 +11,8 @@ class TestDeviceUp(TestCase):
     """
 
     @patch("openfactory.ofa.device.up.OpenFactoryManager")
-    def test_device_up(self, mock_openfactory_manager):
+    @patch("openfactory.ofa.device.up.process_yaml_files")
+    def test_device_up(self, mock_process_yaml_files, mock_openfactory_manager):
         """
         Test deploy_devices_from_config_file called correctly
         """
@@ -21,8 +22,11 @@ class TestDeviceUp(TestCase):
         runner = CliRunner()
         config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                    'mock/mock_devices.yml')
-        result = runner.invoke(ofa.device.click_up, [config_file])
-        mock_instance.deploy_devices_from_config_file.assert_called_once_with(config_file)
+        result = runner.invoke(ofa.device.click_up, [config_file, '--dry-run'])
+        mock_process_yaml_files.assert_called_once_with(config_file, True,
+                                                        action_func=mock_instance.deploy_devices_from_config_file,
+                                                        action_name="deployed",
+                                                        pattern='dev_*.yml')
         self.assertEqual(result.exit_code, 0)
 
     def test_device_up_none_existent_file(self):
@@ -31,8 +35,8 @@ class TestDeviceUp(TestCase):
         """
         runner = CliRunner()
         result = runner.invoke(ofa.device.click_up, ['/does/not/exist/config_file.yml'])
-        expect = ("Usage: up [OPTIONS] YAML_CONFIG_FILE\n"
+        expect = ("Usage: up [OPTIONS] PATH\n"
                   "Try 'up --help' for help.\n"
                   "\n"
-                  "Error: Invalid value for 'YAML_CONFIG_FILE': Path '/does/not/exist/config_file.yml' does not exist.\n")
+                  "Error: Invalid value for 'PATH': Path '/does/not/exist/config_file.yml' does not exist.\n")
         self.assertEqual(result.output, expect)

--- a/tests/openfactory/ofa/test_utils.py
+++ b/tests/openfactory/ofa/test_utils.py
@@ -1,0 +1,121 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from openfactory.ofa.utils import process_yaml_files
+
+
+class TestProcessYamlFiles(unittest.TestCase):
+    """
+    Test the process_yaml_files function
+    """
+
+    @patch('openfactory.ofa.utils.find_yaml_files')
+    @patch('openfactory.ofa.utils.os.path.isdir')
+    @patch('openfactory.ofa.utils.os.path.isfile')
+    @patch('openfactory.ofa.utils.user_notify')
+    def test_process_yaml_files_folder(self, mock_notify, mock_isfile, mock_isdir, mock_find_yaml_files):
+        """ Test the process_yaml_files function with a folder containing YAML files """
+        # Setup the mocks
+        mock_isdir.return_value = True  # Simulate directory being present
+        mock_isfile.return_value = False  # Simulate not being a file
+        mock_find_yaml_files.return_value = ['app_mock1.yml', 'app_mock2.yml']  # Mock the list of YAML files
+
+        # Mock the action function
+        mock_action_func = MagicMock()
+
+        # Run the function
+        process_yaml_files('mock_folder', dry_run=False,
+                           action_func=mock_action_func,
+                           action_name="deployed",
+                           pattern='app_*.yml')
+
+        # Assert the find_yaml_files was called
+        mock_find_yaml_files.assert_called_with('mock_folder', pattern='app_*.yml')
+
+        # Check deployment calls
+        mock_action_func.assert_any_call('app_mock1.yml')
+        mock_action_func.assert_any_call('app_mock2.yml')
+
+        # Check notification for deploying
+        mock_notify.info.assert_any_call("[INFO] Deployed from 'app_mock1.yml' ...")
+        mock_notify.info.assert_any_call("[INFO] Deployed from 'app_mock2.yml' ...")
+
+    @patch('openfactory.ofa.utils.find_yaml_files')
+    @patch('openfactory.ofa.utils.os.path.isdir')
+    @patch('openfactory.ofa.utils.os.path.isfile')
+    @patch('openfactory.ofa.utils.user_notify')
+    def test_process_yaml_files_folder_dry_run(self, mock_notify, mock_isfile, mock_isdir, mock_find_yaml_files):
+        """ Test the process_yaml_files function with a folder containing YAML files on dry-run """
+        # Setup the mocks
+        mock_isdir.return_value = True
+        mock_isfile.return_value = False
+        mock_find_yaml_files.return_value = ['dev_mock1.yml', 'dev_mock2.yml']
+
+        # Mock the action function
+        mock_action_func = MagicMock()
+
+        # Run the function
+        process_yaml_files('mock_folder', dry_run=True,
+                           action_func=mock_action_func,
+                           action_name="deployed",
+                           pattern='dev_*.yml')
+
+        # Assert the find_yaml_files was called
+        mock_find_yaml_files.assert_called_with('mock_folder', pattern='dev_*.yml')
+
+        # Check dry-run notifications
+        mock_notify.info.assert_any_call("[DRY-RUN] dev_mock1.yml would be deployed.")
+        mock_notify.info.assert_any_call("[DRY-RUN] dev_mock2.yml would be deployed.")
+
+        # Ensure the action function was not called
+        mock_action_func.assert_not_called()
+
+    @patch('openfactory.ofa.utils.os.path.isfile')
+    def test_process_yaml_files_file(self, mock_isfile):
+        """ Test the process_yaml_files function with a single YAML file """
+        # Setup the mocks
+        mock_isfile.return_value = True
+
+        # Mock the action function
+        mock_action_func = MagicMock()
+
+        # Run the function
+        process_yaml_files('mock_file.yml', dry_run=False, action_func=mock_action_func, action_name="deployed")
+
+        # Check that the action function was called with the correct file
+        mock_action_func.assert_called_with('mock_file.yml')
+
+    @patch('openfactory.ofa.utils.find_yaml_files')
+    @patch('openfactory.ofa.utils.os.path.isdir')
+    @patch('openfactory.ofa.utils.os.path.isfile')
+    @patch('openfactory.ofa.utils.user_notify')
+    def test_process_yaml_files_no_files_found(self, mock_notify, mock_isfile, mock_isdir, mock_find_yaml_files):
+        """ Test the process_yaml_files function when no YAML files are found """
+        # Setup the mocks
+        mock_isdir.return_value = True  # Simulate directory being present
+        mock_isfile.return_value = False  # Simulate not being a file
+        mock_find_yaml_files.return_value = []  # No YAML files found
+
+        # Run the function
+        process_yaml_files('mock_folder', dry_run=False, action_func=MagicMock(), action_name="deployed")
+
+        # Check that failure notification is triggered
+        mock_notify.fail.assert_called_with("No YAML files found in 'mock_folder'.")
+
+    @patch('openfactory.ofa.utils.os.path.isfile')
+    @patch('openfactory.ofa.utils.user_notify')
+    def test_process_yaml_files_dry_run_file(self, mock_notify, mock_isfile):
+        """ Test the process_yaml_files function with a single file in dry-run mode """
+        # Setup the mocks
+        mock_isfile.return_value = True
+
+        # Mock the action function
+        mock_action_func = MagicMock()
+
+        # Run the function
+        process_yaml_files('mock_file.yml', dry_run=True, action_func=mock_action_func, action_name="processed")
+
+        # Check dry-run notification
+        mock_notify.info.assert_called_with("[DRY-RUN] mock_file.yml would be processed.")
+
+        # Ensure the action function was not called
+        mock_action_func.assert_not_called()

--- a/tests/openfactory/utils/test_find_yaml_files.py
+++ b/tests/openfactory/utils/test_find_yaml_files.py
@@ -1,0 +1,109 @@
+import os
+import tempfile
+import unittest
+from openfactory.utils import find_yaml_files
+
+
+class TestFindYamlFiles(unittest.TestCase):
+    """
+    Unit tests for the find_yaml_files function
+    """
+
+    def test_find_yaml_files_valid_directory(self):
+        """ Test finding YAML files in a valid directory """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create some YAML files matching the pattern
+            file1 = os.path.join(temp_dir, 'app_test1.yml')
+            file2 = os.path.join(temp_dir, 'app_test2.yml')
+            with open(file1, 'w') as f:
+                f.write('test: 1')
+            with open(file2, 'w') as f:
+                f.write('test: 2')
+
+            # Create a non-matching file
+            non_matching_file = os.path.join(temp_dir, 'not_app.yml')
+            with open(non_matching_file, 'w') as f:
+                f.write('test: 3')
+
+            # Call the function
+            result = find_yaml_files(temp_dir)
+
+            # Assert that only matching files are returned
+            self.assertEqual(len(result), 2)
+            self.assertIn(file1, result)
+            self.assertIn(file2, result)
+            self.assertNotIn(non_matching_file, result)
+
+    def test_find_yaml_files_invalid_directory(self):
+        """ Test finding YAML files in an invalid directory """
+        invalid_dir = '/non/existent/directory'
+        with self.assertRaises(ValueError) as context:
+            find_yaml_files(invalid_dir)
+        self.assertEqual(str(context.exception), f"{invalid_dir} is not a valid directory.")
+
+    def test_find_yaml_files_recursive_search(self):
+        """ Test finding YAML files in a directory and its subdirectories """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            sub_dir = os.path.join(temp_dir, 'subdir')
+            os.makedirs(sub_dir)
+
+            # Create YAML files in both directories
+            file1 = os.path.join(temp_dir, 'app_test1.yml')
+            file2 = os.path.join(sub_dir, 'app_test2.yml')
+            with open(file1, 'w') as f:
+                f.write('test: 1')
+            with open(file2, 'w') as f:
+                f.write('test: 2')
+
+            # Call the function
+            result = find_yaml_files(temp_dir)
+
+            # Assert that files from both directories are returned
+            self.assertEqual(len(result), 2)
+            self.assertIn(file1, result)
+            self.assertIn(file2, result)
+
+    def test_find_yaml_files_no_matching_files(self):
+        """ Test finding YAML files when no files match the pattern """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create files that do not match the pattern
+            file1 = os.path.join(temp_dir, 'not_app1.yml')
+            file2 = os.path.join(temp_dir, 'not_app2.yml')
+            with open(file1, 'w') as f:
+                f.write('test: 1')
+            with open(file2, 'w') as f:
+                f.write('test: 2')
+
+            # Call the function
+            result = find_yaml_files(temp_dir)
+
+            # Assert that no files are returned
+            self.assertEqual(len(result), 0)
+
+    def test_find_yaml_files_empty_directory(self):
+        """ Test finding YAML files in an empty directory """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Call the function on an empty directory
+            result = find_yaml_files(temp_dir)
+
+            # Assert that no files are returned
+            self.assertEqual(len(result), 0)
+
+    def test_find_yaml_files_custom_pattern(self):
+        """ Test finding YAML files with a custom pattern """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create files with a custom pattern
+            file1 = os.path.join(temp_dir, 'custom_test1.yml')
+            file2 = os.path.join(temp_dir, 'custom_test2.yml')
+            with open(file1, 'w') as f:
+                f.write('test: 1')
+            with open(file2, 'w') as f:
+                f.write('test: 2')
+
+            # Call the function with a custom pattern
+            result = find_yaml_files(temp_dir, pattern='custom_*.yml')
+
+            # Assert that only files matching the custom pattern are returned
+            self.assertEqual(len(result), 2)
+            self.assertIn(file1, result)
+            self.assertIn(file2, result)


### PR DESCRIPTION
Allow `ofa` to deploy from a folder by searching `YAML` files matching patters (`dev_*.yml` for devices and `app_*.yml` for OpenFactory applications).